### PR TITLE
Forge: Fix critical VPC and Bastion configuration issues

### DIFF
--- a/bastion_instance.yml
+++ b/bastion_instance.yml
@@ -47,12 +47,6 @@
             Name: "Bastion"
             Project: profile
           exact_count: 1
-          #count_tag:
-          #  Name: "Bastion"
-           # Project: profile
-          #group_id: "{{BastionSG_out.group_id}}"
+          group_id: "{{BastionSG_out.group_id}}"
           vpc_subnet_id: "{{pubsub1}}"
         register: bastionHost_out
-
-
-

--- a/vpc_setup.yml
+++ b/vpc_setup.yml
@@ -62,33 +62,33 @@
         az: "{{zone1}}"
         state: "{{state}}"
         cidr: "{{PriSub1Cidr}}"
-        map_public: yes
+        map_public: no
         resource_tags:
-          Name: vprofile-pubsub4
+          Name: vprofile-prisub1
       register: prisub1_out
 
     - name: Create Private Subnet 2 in Zone2
       ec2_vpc_subnet:
         vpc_id: "{{vpcout.vpc.id}}"
         region: "{{region}}"
-        az: "{{zone1}}"
+        az: "{{zone2}}"
         state: "{{state}}"
         cidr: "{{PriSub2Cidr}}"
-        map_public: yes
+        map_public: no
         resource_tags:
-          Name: vprofile-pubsub5
+          Name: vprofile-prisub2
       register: prisub2_out
 
     - name: Create Private Subnet 3 in Zone3
       ec2_vpc_subnet:
         vpc_id: "{{vpcout.vpc.id}}"
         region: "{{region}}"
-        az: "{{zone1}}"
+        az: "{{zone3}}"
         state: "{{state}}"
         cidr: "{{PriSub3Cidr}}"
-        map_public: yes
+        map_public: no
         resource_tags:
-          Name: vprofile-pubsub6
+          Name: vprofile-prisub3
       register: prisub3_out
 
     - name: Internet Gateway Setup 
@@ -158,4 +158,3 @@
       copy:
         content: "vpcid: {{ vpcout.vpc.id }}\nprisub1: {{ prisub1_out.subnet.id }}\nprisub2: {{ prisub2_out.subnet.id }}\nprisub3: {{ prisub3_out.subnet.id }}\npubsub1: {{ pubsub1_out.subnet.id }}\npubsub2: {{ pubsub2_out.subnet.id }}\npubsub3: {{ pubsub3_out.subnet.id }}\nNATWid: {{ NATGW_out.nat_gateway_id }}\nigwid: {{ igw_out.gateway_id }}\nprivRTid: {{ privRT_out.route_table.id }}"
         dest: vars/output_vars
-


### PR DESCRIPTION
## Forge Code Agent

### Plan
## Fix Critical Issues in VPC and Bastion Configuration

**Summary:** Fix hardcoded availability zones for private subnets, correct public IP mapping, fix subnet naming, and attach security group to Bastion instance.

### 1. **vpc_setup.yml** — Fix private subnet availability zones and public IP mapping
   - **Line 65:** Change `map_public: yes` to `map_public: no` for Private Subnet 1
   - **Line 67:** Change tag name from `vprofile-pubsub4` to `vprofile-prisub1`
   - **Line 74:** Change `az: "{{zone1}}"` to `az: "{{zone2}}"` for Private Subnet 2
   - **Line 77:** Change `map_public: yes` to `map_public: no` for Private Subnet 2
   - **Line 79:** Change tag name from `vprofile-pubsub5` to `vprofile-prisub2`
   - **Line 86:** Change `az: "{{zone1}}"` to `az: "{{zone3}}"` for Private Subnet 3
   - **Line 89:** Change `map_public: yes` to `map_public: no` for Private Subnet 3
   - **Line 91:** Change tag name from `vprofile-pubsub6` to `vprofile-prisub3`

### 2. **bastion_instance.yml** — Attach security group to Bastion instance
   - **Line 53:** Uncomment `group_id: "{{BastionSG_out.group_id}}"` to attach the security group to the EC2 instance


*This PR was generated by Forge Code Agent.*